### PR TITLE
Fix buff list count in for loop

### DIFF
--- a/KTM 17.35/KLHThreatMeter/Code/KTM_Data.lua
+++ b/KTM 17.35/KLHThreatMeter/Code/KTM_Data.lua
@@ -274,7 +274,7 @@ me.isbuffpresent = function(texture)
 	local x
 	local bufftexture
 	
-	for x = 1, 16 do
+	for x = 1, 32 do
 		bufftexture = UnitBuff("player", x)
 		
 		if bufftexture == nil then


### PR DESCRIPTION
Increased beneficial buff count from 16 to 32, otherwise this runs the risk of missing salvation if on a higher buff slot